### PR TITLE
Enable stats tracking and cut input from prepare

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,4 +7,4 @@ RUN curl -s https://coduno.github.io/cli/install.sh | bash -s - -y
 
 WORKDIR /run
 
-ENTRYPOINT ["/bin/bash", "-c", "coduno prepare > prepare.log && coduno run --stats"]
+ENTRYPOINT ["/bin/bash", "-c", "coduno prepare < /dev/null > prepare.log && coduno run --stats"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,4 +7,4 @@ RUN curl -s https://coduno.github.io/cli/install.sh | bash -s - -y
 
 WORKDIR /run
 
-ENTRYPOINT ["/bin/bash", "-c", "coduno prepare > prepare.log && coduno run"]
+ENTRYPOINT ["/bin/bash", "-c", "coduno prepare > prepare.log && coduno run --stats"]


### PR DESCRIPTION
Added the --stats flag to `coduno run` to enable system usage tracking.

stdin for `coduno prepare` should be `/dev/null` so it may not be abused to get at input from the tester-program as part of the setup phase.
